### PR TITLE
Feat - Add `should-lint-lockfile` input to control the linting of the lockfile

### DIFF
--- a/.github/workflows/js--emberjs-addons.yml
+++ b/.github/workflows/js--emberjs-addons.yml
@@ -33,6 +33,12 @@ on:
         required: false
         type: string
 
+      should-lint-lockfile:
+        description: If the job to lint lockfile should run or not.
+        default: true
+        required: false
+        type: boolean
+
 jobs:
   lint-tests:
     name: Lint and tests
@@ -50,6 +56,7 @@ jobs:
 
       # https://github.com/lirantal/lockfile-lint
       - name: Lint lockfile
+        if: ${{ inputs.should-lint-lockfile }}
         run: |
           if [ "${{ inputs.package-manager }}" = "npm" ]; then
             npx lockfile-lint --path package-lock.json --allowed-hosts npm yarn --validate-https

--- a/.github/workflows/js--emberjs-addons.yml
+++ b/.github/workflows/js--emberjs-addons.yml
@@ -108,7 +108,7 @@ jobs:
           elif [ "${{ inputs.package-manager }}" = "yarn" ]; then
             yarn install --no-lockfile --non-interactive
           elif [ "${{ inputs.package-manager }}" = "pnpm" ]; then
-            pnpm install --no-lockfile 
+            pnpm install --no-lockfile
           else
             echo "Unsupported package manager: ${{ inputs.package-manager }}"
             exit 1


### PR DESCRIPTION
## Note to reviewers

Once you have reviewed this PR, please review the following one as well:
https://github.com/DazzlingFugu/ember-reading-time/pull/171

---

## Feat

#### Add `should-lint-lockfile` input to control the linting of the lockfile (#2)

We currently have an issue in `ember-reading-time` where all pipelines fail, which is caused by the version of Node.js (v14) we use and it is not supported anymore due to a recent change in the source code of the Github Action `lockfile-lint`.

- Error we are having:
  https://github.com/DazzlingFugu/ember-reading-time/actions/runs/7937277494/job/21683383771?pr=166

  ![image](https://github.com/DazzlingFugu/.github/assets/47531779/e45e6e74-0604-4eee-b550-5d2cae2f2def)

- Node.js v14 being used in `ember-reading-time`:
  https://github.com/DazzlingFugu/ember-reading-time/actions/runs/8026155957/workflow
  https://github.com/DazzlingFugu/ember-reading-time/blob/d5e881dfff33cb3ce438a2e108631f01437744d1/.github/workflows/ci.yml

- I made an attempt to use Node.js v16 instead, it appears to fix the error but we get different errors: (another problem to solve later)
  https://github.com/DazzlingFugu/ember-reading-time/actions/runs/8030366522/job/21937683314

- The error comes from these lines:
  https://github.com/lirantal/lockfile-lint/blob/5278050700971f18a59114c362bc234836d24f14/packages/lockfile-lint-api/src/ParseLockfile.js#L34-L35

  ```js
  Object.hasOwn(sampleValue, 'version') &&
  (Object.hasOwn(sampleValue, 'resolved') || Object.hasOwn(sampleValue, 'resolution'))
  ```

  that were updated here:
  https://github.com/lirantal/lockfile-lint/commit/217f67d3490fa93c9e95227729e9c41314d82cb6#diff-3ce6d2c32203200a2f67ec457643b02f015d2b60fa87fd5e6f6bea3f2c35007f

  ```js
  sampleValue.hasOwnProperty('version') &&
  (sampleValue.hasOwnProperty('resolved') || sampleValue.hasOwnProperty('resolution'))
  ```